### PR TITLE
Make member functions `const` where appropriate. Duplicated code, but awaiting GCC to use explicit object parameter.

### DIFF
--- a/2023-06-22-determinant-inheritance/main.cpp
+++ b/2023-06-22-determinant-inheritance/main.cpp
@@ -44,5 +44,5 @@ int main() {
 
     std::cout << "determinant of matrixTwo: " << getDeterminant(matrixTwo) << '\n';
 
-    std::cout << "matrixOne[2, 3]: " << matrixOne.at(2)[3] << '\n';
+    std::cout << "matrixOne[2, 3]: " << matrixOne.at(2, 3) << '\n';
 }

--- a/2023-06-22-determinant-inheritance/matrix.h
+++ b/2023-06-22-determinant-inheritance/matrix.h
@@ -25,8 +25,24 @@ class Matrix {
         return data[row];
     }
 
+    constexpr const std::array<double, C>& operator[](std::size_t row) const {
+        return data[row];
+    }
+
     constexpr std::array<double, C>& at(std::size_t row) {
         return data.at(row);
+    }
+
+    constexpr const std::array<double, C>& at(std::size_t row) const {
+        return data.at(row);
+    }
+
+    constexpr double& at(std::size_t row, std::size_t column) {
+        return data.at(row).at(column);
+    }
+
+    constexpr const double& at(std::size_t row, std::size_t column) const {
+        return data.at(row).at(column);
     }
 
     friend Matrix operator+(const Matrix& lhs, const Matrix& rhs) {


### PR DESCRIPTION
Fixes #9